### PR TITLE
Changed collision logic.

### DIFF
--- a/src/decomp/game/mario.c
+++ b/src/decomp/game/mario.c
@@ -1324,8 +1324,10 @@ void update_mario_geometry_inputs(struct MarioState *m) {
     f32 gasLevel;
     f32 ceilToFloorDist;
 
-    f32_find_wall_collision(&m->pos[0], &m->pos[1], &m->pos[2], 60.0f, 50.0f);
-    f32_find_wall_collision(&m->pos[0], &m->pos[1], &m->pos[2], 30.0f, 24.0f);
+    // We want to allow Mario to be able to climb the same steps lara would. 
+    // We will only retain big wall check and increase it's displacement to 65 units to allow Mario to reach the same height.
+    f32_find_wall_collision(&m->pos[0], &m->pos[1], &m->pos[2], 65.0f, 50.0f);
+    //f32_find_wall_collision(&m->pos[0], &m->pos[1], &m->pos[2], 30.0f, 24.0f);
 
     m->floorHeight = find_floor(m->pos[0], m->pos[1], m->pos[2], &m->floor);
 

--- a/src/decomp/game/mario_step.c
+++ b/src/decomp/game/mario_step.c
@@ -263,8 +263,10 @@ static s32 perform_ground_quarter_step(struct MarioState *m, Vec3f nextPos) {
     f32 floorHeight;
     f32 waterLevel;
 
-    lowerWall = resolve_and_return_wall_collisions(nextPos, 30.0f, 24.0f);
-    upperWall = resolve_and_return_wall_collisions(nextPos, 60.0f, 50.0f);
+    // We want to allow Mario to be able to climb the same steps lara would. 
+    // We will only retain big wall check and increase it's displacement to 65 units to allow Mario to reach the same height.
+    //lowerWall = resolve_and_return_wall_collisions(nextPos, 30.0f, 24.0f);
+    upperWall = resolve_and_return_wall_collisions(nextPos, 65.0f, 50.0f);
 
     floorHeight = find_floor(nextPos[0], nextPos[1], nextPos[2], &floor);
     ceilHeight = vec3f_find_ceil(nextPos, floorHeight, &ceil);


### PR DESCRIPTION
This allows Mario to climb normal steps as Lara does without stumbling.

This allows Mario to climb normal steps as Lara does without stumbling.

The original implementation has 2 types of walls:

- small 30units height walls that allow Mario to keep a running animation against them.
- walls with 60units or higher that will stumble Mario and start the push animation.

![image](https://user-images.githubusercontent.com/8367895/182054903-0393ff3f-00bb-43f9-acf7-737754e52635.png)

[More Information about how the collision works in this video.](https://www.youtube.com/watch?v=UnU7DJXiMAQ)

This commit removes small walls check since we want Mario to actually climb them as steps and the definition of high walls was changed from 60 units to 65 units which is an approximation to what Lara can climb as stairs.

Example of the patch it in action: https://www.youtube.com/watch?v=ehZvUcx8M28