### PR TITLE
Fixed segfault for deleted colision surfaces.

### DIFF
--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -697,11 +697,12 @@ void* audio_thread(void* keepAlive)
 
 void copy_debug_collision_surface(struct SM64DebugSurface *dst, struct Surface *src)
 {
-	if( src != NULL ) {
+	if( src ) {
 		vec3i_copy(dst->v1, src->vertex1);
 		vec3i_copy(dst->v2, src->vertex2);
 		vec3i_copy(dst->v3, src->vertex3);
 		dst->normaly = src->normal.y;
+		dst->surfacePointer = (uintptr_t)src;
 	}
 	else
 	{
@@ -709,14 +710,25 @@ void copy_debug_collision_surface(struct SM64DebugSurface *dst, struct Surface *
 		vec3i_reset(dst->v2, 0);
 		vec3i_reset(dst->v3, 0);
 		dst->normaly=0.0f;
+		dst->surfacePointer = (uintptr_t)src;
 	}	
 }
 
 void sm64_get_collision_surfaces(struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall)
 {
-	copy_debug_collision_surface(floor, gMarioState->floor);
-	copy_debug_collision_surface(wall, gMarioState->wall);
-	copy_debug_collision_surface(ceiling, gMarioState->ceil);
+	if(floor->surfacePointer != (uintptr_t) gMarioState->floor )
+	{
+		copy_debug_collision_surface(floor, gMarioState->floor);
+	}
+
+	if(wall->surfacePointer != (uintptr_t) gMarioState->wall )
+	{
+		copy_debug_collision_surface(wall, gMarioState->wall);
+	}
+
+	if(ceiling->surfacePointer != (uintptr_t) gMarioState->ceil ){
+		copy_debug_collision_surface(ceiling, gMarioState->ceil);
+	}
 }
 
 struct SM64DebugSurface *sm64_get_all_surfaces(int *surfacesCount)

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -115,6 +115,7 @@ struct SM64DebugSurface
     int v2[3];
     int v3[3];
     float normaly;
+    uintptr_t surfacePointer;
 };
 
 typedef void (*SM64DebugPrintFunctionPtr)( const char * );


### PR DESCRIPTION
When Objects were deleted from sm64 side the pointers for mario state last floor and ceiling were not properly updated and thus it would try to access invalid memory. Now if the pointer for those surfaces remain the same we won't try to even read them. This is an optimization that also fixes the invalid memory access.