### PR TITLE
New room management support for surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ run-test
 *.so
 compile_commands.json
 /.cache/
+*.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(Windows) Launch",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/../../../bin/OpenLara_mingw.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/../../../bin",
+            "environment": [],
+            "console": "externalTerminal",
+            "preLaunchTask": "compileanddeploy",
+        }
+
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,32 @@
             "environment": [],
             "console": "externalTerminal",
             "preLaunchTask": "compileanddeploy",
+        },
+        {
+            "name": "(gdb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/../../../bin/OpenLara_mingw.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/../../../bin",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description":  "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "compileanddeploy"
         }
 
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "makefile.extensionOutputFolder": "./.vscode"
+    "makefile.extensionOutputFolder": "./.vscode",
+    "files.associations": {
+        "external_types.h": "c"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "makefile.extensionOutputFolder": "./.vscode",
     "files.associations": {
-        "external_types.h": "c"
+        "external_types.h": "c",
+        "functional": "c"
     }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "compilemake",
+            "type": "shell",
+            "command": "make"
+        },
+        {
+            "label": "compileanddeploy",
+            "command": "xcopy .\\dist\\sm64.dll ..\\..\\..\\bin\\sm64.dll /Y",
+            "args": [],
+            "type": "shell",
+            "dependsOn": [
+                "compilemake"
+            ]
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ default: lib
 
 CC      := gcc
 CXX 	:= g++
-CFLAGS  := -g -Wall -fPIC -DSM64_LIB_EXPORT -DVERSION_US -DNO_SEGMENTED_MEMORY -DGBI_FLOATS
-LDFLAGS := -lm -shared -lpthread
+CFLAGS  := -g -Wall -fPIC -DSM64_LIB_EXPORT -DVERSION_US -DNO_SEGMENTED_MEMORY -DGBI_FLOATS -DDEBUG_LEVEL_ROOMS
+LDFLAGS := -g -lm -shared -lpthread
 ENDFLAGS := -fPIC
 ifeq ($(OS),Windows_NT)
 LDFLAGS := $(LDFLAGS)
-ENDFLAGS := -static -lole32 -lstdc++
+ENDFLAGS := -g -static -lole32 -lstdc++
 endif
 
 SRC_DIRS  := src src/decomp src/decomp/engine src/decomp/include/PR src/decomp/game src/decomp/pc src/decomp/pc/audio src/decomp/mario src/decomp/tools src/decomp/audio

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CC      := gcc
 CXX 	:= g++
 CFLAGS  := -g -Wall -fPIC -DSM64_LIB_EXPORT -DVERSION_US -DNO_SEGMENTED_MEMORY -DGBI_FLOATS -DDEBUG_LEVEL_ROOMS
 LDFLAGS := -g -lm -shared -lpthread
-ENDFLAGS := -fPIC
+ENDFLAGS := -g -fPIC
 ifeq ($(OS),Windows_NT)
 LDFLAGS := $(LDFLAGS)
 ENDFLAGS := -g -static -lole32 -lstdc++

--- a/src/decomp/engine/math_util.c
+++ b/src/decomp/engine/math_util.c
@@ -1553,6 +1553,21 @@ void *vec3i_reset(Vec3i dest, s32 value) {
     return &dest; //! warning: function returns address of local variable
 }
 
+void *vec3i2f_copy(Vec3f dest, Vec3i src) {
+    dest[0] = (float)src[0];
+    dest[1] = (float)src[1];
+    dest[2] = (float)src[2];
+    return &dest; //! warning: function returns address of local variable
+}
+
+/// Set vector 'dest' to (x, y, z)
+void *vec3f_reset(Vec3f dest, f32 value) {
+    dest[0] = value;
+    dest[1] = value;
+    dest[2] = value;
+    return &dest; //! warning: function returns address of local variable
+}
+
 /**
  * Convert float vector a to a short vector 'dest' by rounding the components
  * to the nearest integer.

--- a/src/decomp/engine/math_util.h
+++ b/src/decomp/engine/math_util.h
@@ -47,6 +47,8 @@ void *vec3f_to_vec3s(Vec3s dest, Vec3f a);
 void *vec3i_copy(Vec3i dest, Vec3i src);
 void *vec3i_set(Vec3i dest, s32 x, s32 y, s32 z);
 void *vec3i_reset(Vec3i dest, s32 value);
+void *vec3i2f_copy(Vec3f dest, Vec3i src);
+void *vec3f_reset(Vec3f dest, f32 value);
 void *find_vector_perpendicular_to_plane(Vec3f dest, Vec3f a, Vec3f b, Vec3f c);
 void *vec3f_cross(Vec3f dest, Vec3f a, Vec3f b);
 void *vec3f_normalize(Vec3f dest);
@@ -75,7 +77,6 @@ f32 atan2f(f32 a, f32 b);
 void spline_get_weights(Vec4f result, f32 t, UNUSED s32 c);
 void anim_spline_init(Vec4s *keyFrames);
 s32 anim_spline_poll(Vec3f result);
-
 
 // From object_helpers.c
 void linear_mtxf_mul_vec3f(Mat4 m, Vec3f dst, Vec3f v);

--- a/src/decomp/engine/surface_collision.c
+++ b/src/decomp/engine/surface_collision.c
@@ -7,9 +7,9 @@ struct Surface **get_all_geometry(int *count){
 
     uint32_t numberOfSurfaces=0;
 
-    uint32_t groupCount = level_get_all_surface_group_count();
+    uint32_t groupCount = level_get_room_count();
     for( int i = 0; i < groupCount-1; ++i ) {
-        uint32_t surfCount = level_get_all_surface_group_size( i );
+        uint32_t surfCount = level_get_room_surfaces_count( i );
         numberOfSurfaces+=surfCount;
     }
 
@@ -17,9 +17,9 @@ struct Surface **get_all_geometry(int *count){
 
     uint32_t sindex=0;
     for( int i = 0; i < groupCount-1; ++i ) {
-        uint32_t surfCount = level_get_all_surface_group_size( i );
+        uint32_t surfCount = level_get_room_surfaces_count( i );
         for( int j = 0; j < surfCount; ++j ) {
-            struct Surface * ls = level_get_surface_index( i, j );
+            struct Surface * ls = level_get_room_surface( i, j );
             if(i>=(groupCount-1)/2)
             {
                 ls->room=1;
@@ -35,13 +35,13 @@ struct Surface **get_all_geometry(int *count){
 
 struct Surface **get_dynamic_geometry(int *count){
 
-    uint32_t groupCount = level_get_all_surface_group_count();
-    uint32_t numberOfSurfaces = level_get_all_surface_group_size( groupCount-1 );
+    uint32_t groupCount = level_get_room_count();
+    uint32_t numberOfSurfaces = level_get_room_surfaces_count( groupCount-1 );
 
     struct Surface **dynamicSurfaces = (struct Surface **)malloc(sizeof(struct Surface *)*numberOfSurfaces);
 
     for( int i = 0; i < numberOfSurfaces; i++ ) {
-        struct Surface * ls = level_get_surface_index( groupCount-1, i );
+        struct Surface * ls = level_get_room_surface( groupCount-1, i );
         ls->room=2;
         dynamicSurfaces[i]=ls;
     }
@@ -61,11 +61,11 @@ static struct Surface *find_ceil_from_list( s32 x, s32 y, s32 z, f32 *pheight) {
 
     ceil = NULL;
 
-    uint32_t groupCount = level_get_all_surface_group_count();
+    uint32_t groupCount = level_get_room_count();
     for( int i = 0; i < groupCount; ++i ) {
-    uint32_t surfCount = level_get_all_surface_group_size( i );
+    uint32_t surfCount = level_get_room_surfaces_count( i );
     for( int j = 0; j < surfCount; ++j ) {
-        surf = level_get_surface_index( i, j );
+        surf = level_get_room_surface( i, j );
 
         // libsm64: Weed out surfaces whose triangles are actually line segs. TODO do this at surface load time
         if( !surf->isValid ) continue;
@@ -139,11 +139,11 @@ static struct Surface *find_floor_from_list( s32 x, s32 y, s32 z, f32 *pheight) 
 
     level_update_big_floor_hack(x, y, z);
 
-    uint32_t groupCount = level_get_all_surface_group_count();
+    uint32_t groupCount = level_get_room_count();
     for( int i = 0; i < groupCount; ++i ) {
-    uint32_t surfCount = level_get_all_surface_group_size( i );
+    uint32_t surfCount = level_get_room_surfaces_count( i );
     for( int j = 0; j < surfCount; ++j ) {
-        surf = level_get_surface_index( i, j );
+        surf = level_get_room_surface( i, j );
 
         // libsm64: Weed out surfaces whose triangles are actually line segs. TODO do this at surface load time
         if( !surf->isValid ) continue;
@@ -215,11 +215,11 @@ static s32 find_wall_collisions_from_list( struct WallCollisionData *data) {
         radius = 200.0f;
     }
 
-    uint32_t groupCount = level_get_all_surface_group_count();
+    uint32_t groupCount = level_get_room_count();
     for( int i = 0; i < groupCount; ++i ) {
-    uint32_t surfCount = level_get_all_surface_group_size( i );
+    uint32_t surfCount = level_get_room_surfaces_count( i );
     for( int j = 0; j < surfCount; ++j ) {
-        surf = level_get_surface_index( i, j );
+        surf = level_get_room_surface( i, j );
 
         // libsm64: Weed out surfaces whose triangles are actually line segs. TODO do this at surface load time
         if( !surf->isValid ) continue;

--- a/src/decomp/engine/surface_collision.c
+++ b/src/decomp/engine/surface_collision.c
@@ -41,7 +41,7 @@ struct Surface **get_dynamic_geometry(int *count){
     struct Surface **dynamicSurfaces = (struct Surface **)malloc(sizeof(struct Surface *)*numberOfSurfaces);
 
     for( int i = 0; i < numberOfSurfaces; i++ ) {
-        struct Surface * ls = level_get_surface_index( groupCount-1, i++ );
+        struct Surface * ls = level_get_surface_index( groupCount-1, i );
         ls->room=2;
         dynamicSurfaces[i]=ls;
     }

--- a/src/decomp/engine/surface_collision.c
+++ b/src/decomp/engine/surface_collision.c
@@ -7,9 +7,9 @@ struct Surface **get_all_geometry(int *count){
 
     uint32_t numberOfSurfaces=0;
 
-    uint32_t groupCount = loaded_surface_iter_group_count();
+    uint32_t groupCount = level_get_all_surface_group_count();
     for( int i = 0; i < groupCount; ++i ) {
-        uint32_t surfCount = loaded_surface_iter_group_size( i );
+        uint32_t surfCount = level_get_all_surface_group_size( i );
         numberOfSurfaces+=surfCount;
     }
 
@@ -17,9 +17,9 @@ struct Surface **get_all_geometry(int *count){
 
     uint32_t sindex=0;
     for( int i = 0; i < groupCount; ++i ) {
-        uint32_t surfCount = loaded_surface_iter_group_size( i );
+        uint32_t surfCount = level_get_all_surface_group_size( i );
         for( int j = 0; j < surfCount; ++j ) {
-            struct Surface * ls = loaded_surface_iter_get_at_index( i, j );
+            struct Surface * ls = level_get_surface_index( i, j );
             allSurfaces[sindex++]=ls;
         }
     }
@@ -38,11 +38,11 @@ static struct Surface *find_ceil_from_list( s32 x, s32 y, s32 z, f32 *pheight) {
 
     ceil = NULL;
 
-    uint32_t groupCount = loaded_surface_iter_group_count();
+    uint32_t groupCount = level_get_all_surface_group_count();
     for( int i = 0; i < groupCount; ++i ) {
-    uint32_t surfCount = loaded_surface_iter_group_size( i );
+    uint32_t surfCount = level_get_all_surface_group_size( i );
     for( int j = 0; j < surfCount; ++j ) {
-        surf = loaded_surface_iter_get_at_index( i, j );
+        surf = level_get_surface_index( i, j );
 
         // libsm64: Weed out surfaces whose triangles are actually line segs. TODO do this at surface load time
         if( !surf->isValid ) continue;
@@ -114,11 +114,11 @@ static struct Surface *find_floor_from_list( s32 x, s32 y, s32 z, f32 *pheight) 
     f32 height;
     struct Surface *floor = NULL;
 
-    uint32_t groupCount = loaded_surface_iter_group_count();
+    uint32_t groupCount = level_get_all_surface_group_count();
     for( int i = 0; i < groupCount; ++i ) {
-    uint32_t surfCount = loaded_surface_iter_group_size( i );
+    uint32_t surfCount = level_get_all_surface_group_size( i );
     for( int j = 0; j < surfCount; ++j ) {
-        surf = loaded_surface_iter_get_at_index( i, j );
+        surf = level_get_surface_index( i, j );
 
         // libsm64: Weed out surfaces whose triangles are actually line segs. TODO do this at surface load time
         if( !surf->isValid ) continue;
@@ -190,11 +190,11 @@ static s32 find_wall_collisions_from_list( struct WallCollisionData *data) {
         radius = 200.0f;
     }
 
-    uint32_t groupCount = loaded_surface_iter_group_count();
+    uint32_t groupCount = level_get_all_surface_group_count();
     for( int i = 0; i < groupCount; ++i ) {
-    uint32_t surfCount = loaded_surface_iter_group_size( i );
+    uint32_t surfCount = level_get_all_surface_group_size( i );
     for( int j = 0; j < surfCount; ++j ) {
-        surf = loaded_surface_iter_get_at_index( i, j );
+        surf = level_get_surface_index( i, j );
 
         // libsm64: Weed out surfaces whose triangles are actually line segs. TODO do this at surface load time
         if( !surf->isValid ) continue;

--- a/src/decomp/engine/surface_collision.c
+++ b/src/decomp/engine/surface_collision.c
@@ -8,7 +8,7 @@ struct Surface **get_all_geometry(int *count){
     uint32_t numberOfSurfaces=0;
 
     uint32_t groupCount = level_get_all_surface_group_count();
-    for( int i = 0; i < groupCount; ++i ) {
+    for( int i = 0; i < groupCount-1; ++i ) {
         uint32_t surfCount = level_get_all_surface_group_size( i );
         numberOfSurfaces+=surfCount;
     }
@@ -16,15 +16,11 @@ struct Surface **get_all_geometry(int *count){
     struct Surface **allSurfaces = (struct Surface **)malloc(sizeof(struct Surface *)*numberOfSurfaces);
 
     uint32_t sindex=0;
-    for( int i = 0; i < groupCount; ++i ) {
+    for( int i = 0; i < groupCount-1; ++i ) {
         uint32_t surfCount = level_get_all_surface_group_size( i );
         for( int j = 0; j < surfCount; ++j ) {
             struct Surface * ls = level_get_surface_index( i, j );
-            if(i== groupCount-1)
-            {
-                ls->room=2;
-            }
-            else if(i>=(groupCount-1)/2)
+            if(i>=(groupCount-1)/2)
             {
                 ls->room=1;
             }
@@ -35,6 +31,24 @@ struct Surface **get_all_geometry(int *count){
 
     *count=numberOfSurfaces;
     return allSurfaces;
+}
+
+struct Surface **get_dynamic_geometry(int *count){
+
+    uint32_t groupCount = level_get_all_surface_group_count();
+    uint32_t numberOfSurfaces = level_get_all_surface_group_size( groupCount-1 );
+
+    struct Surface **dynamicSurfaces = (struct Surface **)malloc(sizeof(struct Surface *)*numberOfSurfaces);
+
+    for( int i = 0; i < numberOfSurfaces; i++ ) {
+        struct Surface * ls = level_get_surface_index( groupCount-1, i++ );
+        ls->room=2;
+        dynamicSurfaces[i]=ls;
+    }
+    
+
+    *count=numberOfSurfaces;
+    return dynamicSurfaces;
 }
 
 /**

--- a/src/decomp/engine/surface_collision.c
+++ b/src/decomp/engine/surface_collision.c
@@ -137,6 +137,8 @@ static struct Surface *find_floor_from_list( s32 x, s32 y, s32 z, f32 *pheight) 
     f32 height;
     struct Surface *floor = NULL;
 
+    level_update_big_floor_hack(x, y, z);
+
     uint32_t groupCount = level_get_all_surface_group_count();
     for( int i = 0; i < groupCount; ++i ) {
     uint32_t surfCount = level_get_all_surface_group_size( i );

--- a/src/decomp/engine/surface_collision.c
+++ b/src/decomp/engine/surface_collision.c
@@ -20,7 +20,16 @@ struct Surface **get_all_geometry(int *count){
         uint32_t surfCount = level_get_all_surface_group_size( i );
         for( int j = 0; j < surfCount; ++j ) {
             struct Surface * ls = level_get_surface_index( i, j );
-            allSurfaces[sindex++]=ls;
+            if(i== groupCount-1)
+            {
+                ls->room=2;
+            }
+            else if(i>=(groupCount-1)/2)
+            {
+                ls->room=1;
+            }
+            allSurfaces[sindex]=ls;
+            sindex++;
         }
     }
 

--- a/src/decomp/engine/surface_collision.h
+++ b/src/decomp/engine/surface_collision.h
@@ -41,5 +41,6 @@ f32 find_floor(f32 xPos, f32 yPos, f32 zPos, struct Surface **pfloor);
 f32 find_water_level(f32 x, f32 z);
 f32 find_poison_gas_level(f32 x, f32 z);
 struct Surface **get_all_geometry(int *count);
+struct Surface **get_dynamic_geometry(int *count);
 
 #endif // SURFACE_COLLISION_H

--- a/src/decomp/engine/surface_collision.h
+++ b/src/decomp/engine/surface_collision.h
@@ -1,6 +1,8 @@
 #ifndef SURFACE_COLLISION_H
 #define SURFACE_COLLISION_H
 
+#include <stdbool.h>
+#include <stdlib.h>
 #include "../include/PR/ultratypes.h"
 
 #include "../include/types.h"

--- a/src/decomp/include/external_types.h
+++ b/src/decomp/include/external_types.h
@@ -2,6 +2,7 @@
 #define EXTERNAL_TYPES_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 struct SM64ObjectTransform
 {
@@ -14,6 +15,25 @@ struct SM64SurfaceObject
     struct SM64ObjectTransform transform;
     uint32_t surfaceCount;
     struct SM64Surface *surfaces;
+};
+
+enum SM64ExternalSurfaceTypes
+{
+    EXTERNAL_SURFACE_TYPE_STATIC_SURFACE,
+    EXTERNAL_SURFACE_TYPE_STATIC_MESH,
+    EXTERNAL_SURFACE_TYPE_DYNAMIC_OBJECT,
+    EXTERNAL_SURFACE_TYPE_FLOOR_HACK
+};
+
+struct SM64DebugSurface
+{
+    float v1[3];
+    float v2[3];
+    float v3[3];
+    //float normaly;
+    //uintptr_t surfacePointer;
+    enum SM64ExternalSurfaceTypes color;
+    bool valid;
 };
 
 #endif

--- a/src/decomp/include/external_types.h
+++ b/src/decomp/include/external_types.h
@@ -1,0 +1,19 @@
+#ifndef EXTERNAL_TYPES_H
+#define EXTERNAL_TYPES_H
+
+#include <stdint.h>
+
+struct SM64ObjectTransform
+{
+    float position[3];
+    float eulerRotation[3];
+};
+
+struct SM64SurfaceObject
+{
+    struct SM64ObjectTransform transform;
+    uint32_t surfaceCount;
+    struct SM64Surface *surfaces;
+};
+
+#endif

--- a/src/decomp/include/types.h
+++ b/src/decomp/include/types.h
@@ -7,7 +7,6 @@
 #include "ultra64.h"
 #include "macros.h"
 #include "PR/ultratypes.h"
-#include "external_types.h"
 
 
 // Certain functions are marked as having return values, but do not
@@ -277,8 +276,8 @@ struct Room
     struct Surface *staticSurfaces;
     uint32_t staticSurfacesCount;
 
-    struct LoadedSurfaceObject *loadedObjecs;
-    uint32_t loadedObjecsCount;
+    struct Surface *staticObjectSurfaces;
+    uint32_t staticObjectSurfacesCount;
 };
 
 

--- a/src/decomp/include/types.h
+++ b/src/decomp/include/types.h
@@ -7,6 +7,7 @@
 #include "ultra64.h"
 #include "macros.h"
 #include "PR/ultratypes.h"
+#include "external_types.h"
 
 
 // Certain functions are marked as having return values, but do not
@@ -262,6 +263,24 @@ struct Surface
     struct SurfaceObjectTransform *transform; // libsm64: added field
     u16 terrain; // libsm64: added field
 };
+
+struct LoadedSurfaceObject
+{
+    struct SurfaceObjectTransform *transform;
+    uint32_t surfaceCount;
+    struct Surface *engineSurfaces;
+    struct SM64Surface *libSurfaces;
+};
+
+struct Room
+{
+    struct Surface *staticSurfaces;
+    uint32_t staticSurfacesCount;
+
+    struct LoadedSurfaceObject *loadedObjecs;
+    uint32_t loadedObjecsCount;
+};
+
 
 struct MarioBodyState
 {

--- a/src/decomp/include/types.h
+++ b/src/decomp/include/types.h
@@ -267,8 +267,8 @@ struct LoadedSurfaceObject
 {
     struct SurfaceObjectTransform *transform;
     uint32_t surfaceCount;
-    struct Surface *engineSurfaces;
     struct SM64Surface *libSurfaces;
+    struct Surface *engineSurfaces;    
 };
 
 struct Room

--- a/src/decomp/include/types.h
+++ b/src/decomp/include/types.h
@@ -7,6 +7,7 @@
 #include "ultra64.h"
 #include "macros.h"
 #include "PR/ultratypes.h"
+#include "external_types.h"
 
 
 // Certain functions are marked as having return values, but do not
@@ -261,25 +262,8 @@ struct Surface
     u8 isValid; // libsm64: added field
     struct SurfaceObjectTransform *transform; // libsm64: added field
     u16 terrain; // libsm64: added field
+    enum SM64ExternalSurfaceTypes eSurfaceType; //added external room type
 };
-
-struct LoadedSurfaceObject
-{
-    struct SurfaceObjectTransform *transform;
-    uint32_t surfaceCount;
-    struct SM64Surface *libSurfaces;
-    struct Surface *engineSurfaces;    
-};
-
-struct Room
-{
-    struct Surface *staticSurfaces;
-    uint32_t staticSurfacesCount;
-
-    struct Surface *staticObjectSurfaces;
-    uint32_t staticObjectSurfacesCount;
-};
-
 
 struct MarioBodyState
 {

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -698,7 +698,7 @@ void* audio_thread(void* keepAlive)
 
 void copy_debug_collision_surface(struct SM64DebugSurface *dst, struct Surface *src)
 {
-	if( src ) {
+	if( src && src->isValid ) {
 		vec3i_copy(dst->v1, src->vertex1);
 		vec3i_copy(dst->v2, src->vertex2);
 		vec3i_copy(dst->v3, src->vertex3);
@@ -778,4 +778,14 @@ void sm64_level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfa
 void sm64_level_unload_room(uint32_t roomId)
 {
 	level_unload_room(roomId);
+}
+
+void sm64_level_update_loaded_rooms_list(int *loadedRooms, int loadedCount)
+{
+	level_update_loaded_rooms_list(loadedRooms, loadedCount);
+}
+
+void sm64_level_rooms_switch(int switchedRooms[][2], int switchedRoomsCount)
+{
+	level_rooms_switch(switchedRooms, switchedRoomsCount);
 }

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -727,7 +727,7 @@ void copy_debug_collision_surface(struct SM64DebugSurface *dst, struct Surface *
 	}	
 }
 
-struct SM64DebugSurface *sm64_get_collision_surfaces(int marioId, struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall, int *allSurfacesCount)
+void sm64_get_collision_surfaces(int marioId, struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall, struct SM64DebugSurface surfaces[])
 {
 	level_set_active_mario(marioId);
 
@@ -736,17 +736,30 @@ struct SM64DebugSurface *sm64_get_collision_surfaces(int marioId, struct SM64Deb
 	copy_debug_collision_surface(ceiling, gMarioState->ceil);
 	
 
-	struct Surface **surfaces = level_get_all_loaded_surfaces(allSurfacesCount);
+	int index=0;
+	int roomsCount = level_get_room_count();
+	for(int i=0; i<roomsCount; i++)
+	{
+		int surfCount = level_get_room_surfaces_count(i);
+		for(int j=0; j<surfCount; j++)
+		{
+			copy_debug_collision_surface(&(surfaces[index++]), level_get_room_surface(i, j));
+		}
+	}
+}
 
-	struct SM64DebugSurface *result = (struct SM64DebugSurface*)malloc(sizeof(struct SM64DebugSurface)*(*allSurfacesCount));
+int sm64_get_collision_surfaces_count(int marioId)
+{
+	level_set_active_mario(marioId);
 
-	for(int i=0; i<(*allSurfacesCount); i++) {
-		copy_debug_collision_surface(&(result[i]), surfaces[i]);
+	int resultCount = 0;
+	int roomsCount = level_get_room_count();
+	for(int i=0; i<roomsCount; i++)
+	{
+		resultCount+=level_get_room_surfaces_count(i);
 	}
 
-	free(surfaces);
-
-	return result;
+	return resultCount;
 }
 
 void sm64_level_init(uint32_t roomsCount)

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -183,15 +183,16 @@ SM64_LIB_FN void sm64_global_terminate( void )
 	   
 	ctl_free();
     alloc_only_pool_free( s_mario_geo_pool );
-    surfaces_unload_all();
+    //surfaces_unload_all();
+	level_unload();
     unload_mario_anims();
     memory_terminate();
 }
 
-SM64_LIB_FN void sm64_static_surfaces_load( const struct SM64Surface *surfaceArray, uint32_t numSurfaces )
-{
-    surfaces_load_static( surfaceArray, numSurfaces );
-}
+// SM64_LIB_FN void sm64_static_surfaces_load( const struct SM64Surface *surfaceArray, uint32_t numSurfaces )
+// {
+//     surfaces_load_static( surfaceArray, numSurfaces );
+// }
 
 SM64_LIB_FN int32_t sm64_mario_create( float x, float y, float z, int16_t rx, int16_t ry, int16_t rz, uint8_t fake )
 {
@@ -580,32 +581,32 @@ SM64_LIB_FN bool sm64_mario_attack(int32_t marioId, float x, float y, float z, f
 	return fake_interact_bounce_top(gMarioState, x, y, z, hitboxHeight);
 }
 
-SM64_LIB_FN uint32_t sm64_surface_object_create( const struct SM64SurfaceObject *surfaceObject )
-{
-    uint32_t id = surfaces_load_object( surfaceObject );
-    return id;
-}
+// SM64_LIB_FN uint32_t sm64_surface_object_create( const struct SM64SurfaceObject *surfaceObject )
+// {
+//     uint32_t id = surfaces_load_object( surfaceObject );
+//     return id;
+// }
 
-SM64_LIB_FN void sm64_surface_object_move( uint32_t objectId, const struct SM64ObjectTransform *transform )
-{
-    surface_object_update_transform( objectId, transform );
-}
+// SM64_LIB_FN void sm64_surface_object_move( uint32_t objectId, const struct SM64ObjectTransform *transform )
+// {
+//     surface_object_update_transform( objectId, transform );
+// }
 
-SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId )
-{
-    // A mario standing on the platform that is being destroyed will have a pointer to freed memory if we don't clear it.
-    for( int i = 0; i < s_mario_instance_pool.size; ++i )
-    {
-        if( s_mario_instance_pool.objects[i] == NULL )
-            continue;
+// SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId )
+// {
+//     // A mario standing on the platform that is being destroyed will have a pointer to freed memory if we don't clear it.
+//     for( int i = 0; i < s_mario_instance_pool.size; ++i )
+//     {
+//         if( s_mario_instance_pool.objects[i] == NULL )
+//             continue;
 
-        struct GlobalState *state = ((struct MarioInstance *)s_mario_instance_pool.objects[ i ])->globalState;
-        if( state->mgMarioObject->platform == surfaces_object_get_transform_ptr( objectId ))
-            state->mgMarioObject->platform = NULL;
-    }
+//         struct GlobalState *state = ((struct MarioInstance *)s_mario_instance_pool.objects[ i ])->globalState;
+//         if( state->mgMarioObject->platform == surfaces_object_get_transform_ptr( objectId ))
+//             state->mgMarioObject->platform = NULL;
+//     }
 
-    surfaces_unload_object( objectId );
-}
+//     surfaces_unload_object( objectId );
+// }
 
 SM64_LIB_FN void sm64_seq_player_play_sequence(uint8_t player, uint8_t seqId, uint16_t arg2)
 {
@@ -744,4 +745,24 @@ struct SM64DebugSurface *sm64_get_all_surfaces(int *surfacesCount)
 	free(allSurfaces);
 
 	return result;
+}
+
+void sm64_level_init(uint32_t roomsCount)
+{
+	level_init(roomsCount);
+}
+
+void sm64_level_unload()
+{
+	level_unload();
+}
+
+void sm64_level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces)
+{
+	level_load_room(roomId, staticSurfaces, numSurfaces);
+}
+
+void sm64_level_unload_room(uint32_t roomId)
+{
+	level_unload_room(roomId);
 }

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -309,7 +309,7 @@ SM64_LIB_FN void sm64_mario_tick( int32_t marioId, const struct SM64MarioInputs 
     update_button( inputs->buttonB, B_BUTTON );
     update_button( inputs->buttonZ, Z_TRIG );
 
-	gMarioState->marioObj->header.gfx.cameraToObject[0] = 0;
+	gMarioState->marioObj->header.gfx.cameraToObject[0] = 0; 
 	gMarioState->marioObj->header.gfx.cameraToObject[1] = 0;
 	gMarioState->marioObj->header.gfx.cameraToObject[2] = 0;
 
@@ -704,6 +704,7 @@ void copy_debug_collision_surface(struct SM64DebugSurface *dst, struct Surface *
 		vec3i_copy(dst->v3, src->vertex3);
 		dst->normaly = src->normal.y;
 		dst->surfacePointer = (uintptr_t)src;
+		dst->color = src->room;
 	}
 	else
 	{
@@ -757,9 +758,9 @@ void sm64_level_unload()
 	level_unload();
 }
 
-void sm64_level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces)
+void sm64_level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces, const struct SM64SurfaceObject *staticObjects, uint32_t staticObjectsCount)
 {
-	level_load_room(roomId, staticSurfaces, numSurfaces);
+	level_load_room(roomId, staticSurfaces, numSurfaces, staticObjects, staticObjectsCount);
 }
 
 void sm64_level_unload_room(uint32_t roomId)

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -716,7 +716,7 @@ void copy_debug_collision_surface(struct SM64DebugSurface *dst, struct Surface *
 	}	
 }
 
-void sm64_get_collision_surfaces(struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall)
+struct SM64DebugSurface *sm64_get_collision_surfaces(struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall, int *collidersCount)
 {
 	if(floor->surfacePointer != (uintptr_t) gMarioState->floor )
 	{
@@ -731,6 +731,18 @@ void sm64_get_collision_surfaces(struct SM64DebugSurface *floor, struct SM64Debu
 	if(ceiling->surfacePointer != (uintptr_t) gMarioState->ceil ){
 		copy_debug_collision_surface(ceiling, gMarioState->ceil);
 	}
+
+	struct Surface **colliders = get_dynamic_geometry(collidersCount);
+
+	struct SM64DebugSurface *result = (struct SM64DebugSurface*)malloc(sizeof(struct SM64DebugSurface)*(*collidersCount));
+
+	for(int i=0; i<(*collidersCount); i++) {
+		copy_debug_collision_surface(&(result[i]), colliders[i]);
+	}
+
+	free(colliders);
+
+	return result;
 }
 
 struct SM64DebugSurface *sm64_get_all_surfaces(int *surfacesCount)

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -581,32 +581,32 @@ SM64_LIB_FN bool sm64_mario_attack(int32_t marioId, float x, float y, float z, f
 	return fake_interact_bounce_top(gMarioState, x, y, z, hitboxHeight);
 }
 
-// SM64_LIB_FN uint32_t sm64_surface_object_create( const struct SM64SurfaceObject *surfaceObject )
-// {
-//     uint32_t id = surfaces_load_object( surfaceObject );
-//     return id;
-// }
+SM64_LIB_FN uint32_t sm64_surface_object_create( const struct SM64SurfaceObject *surfaceObject )
+{
+    uint32_t id = level_create_dynamic_object( surfaceObject );
+    return id;
+}
 
-// SM64_LIB_FN void sm64_surface_object_move( uint32_t objectId, const struct SM64ObjectTransform *transform )
-// {
-//     surface_object_update_transform( objectId, transform );
-// }
+SM64_LIB_FN void sm64_surface_object_move( uint32_t objectId, const struct SM64ObjectTransform *transform )
+{
+    level_update_dynamic_object_transform( objectId, transform );
+}
 
-// SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId )
-// {
-//     // A mario standing on the platform that is being destroyed will have a pointer to freed memory if we don't clear it.
-//     for( int i = 0; i < s_mario_instance_pool.size; ++i )
-//     {
-//         if( s_mario_instance_pool.objects[i] == NULL )
-//             continue;
+SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId )
+{
+    // A mario standing on the platform that is being destroyed will have a pointer to freed memory if we don't clear it.
+    for( int i = 0; i < s_mario_instance_pool.size; ++i )
+    {
+        if( s_mario_instance_pool.objects[i] == NULL )
+            continue;
 
-//         struct GlobalState *state = ((struct MarioInstance *)s_mario_instance_pool.objects[ i ])->globalState;
-//         if( state->mgMarioObject->platform == surfaces_object_get_transform_ptr( objectId ))
-//             state->mgMarioObject->platform = NULL;
-//     }
+        struct GlobalState *state = ((struct MarioInstance *)s_mario_instance_pool.objects[ i ])->globalState;
+        if( state->mgMarioObject->platform == level_get_dynamic_object_transform( objectId ))
+            state->mgMarioObject->platform = NULL;
+    }
 
-//     surfaces_unload_object( objectId );
-// }
+    level_remove_dynamic_object( objectId );
+}
 
 SM64_LIB_FN void sm64_seq_player_play_sequence(uint8_t player, uint8_t seqId, uint16_t arg2)
 {

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -194,9 +194,11 @@ SM64_LIB_FN void sm64_global_terminate( void )
 //     surfaces_load_static( surfaceArray, numSurfaces );
 // }
 
-SM64_LIB_FN int32_t sm64_mario_create( float x, float y, float z, int16_t rx, int16_t ry, int16_t rz, uint8_t fake )
+SM64_LIB_FN int32_t sm64_mario_create( float x, float y, float z, int16_t rx, int16_t ry, int16_t rz, uint8_t fake, int *loadedRooms, int loadedCount)
 {
     int32_t marioIndex = obj_pool_alloc_index( &s_mario_instance_pool, sizeof( struct MarioInstance ));
+	level_load_player_loaded_rooms(marioIndex);
+	level_update_player_loaded_Rooms(marioIndex, loadedRooms, loadedCount);
     struct MarioInstance *newInstance = s_mario_instance_pool.objects[marioIndex];
 
     newInstance->globalState = global_state_create();
@@ -272,6 +274,7 @@ SM64_LIB_FN void sm64_mario_anim_tick( int32_t marioId, uint32_t stateFlags, str
         DEBUG_PRINT("Tried to tick non-existant Mario with ID: %u", marioId);
         return;
     }
+	level_set_active_mario(marioId);
 
 	struct GlobalState *state = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
     global_state_bind( state );
@@ -292,13 +295,14 @@ SM64_LIB_FN void sm64_mario_anim_tick( int32_t marioId, uint32_t stateFlags, str
 }
 
 
-SM64_LIB_FN void sm64_mario_tick( int32_t marioId, const struct SM64MarioInputs *inputs, struct SM64MarioState *outState, struct SM64MarioGeometryBuffers *outBuffers )
+SM64_LIB_FN void sm64_mario_tick(int32_t marioId, const struct SM64MarioInputs *inputs, struct SM64MarioState *outState, struct SM64MarioGeometryBuffers *outBuffers )
 {
     if( marioId >= s_mario_instance_pool.size || s_mario_instance_pool.objects[marioId] == NULL )
     {
         DEBUG_PRINT("Tried to tick non-existant Mario with ID: %u", marioId);
         return;
     }
+	level_set_active_mario(marioId);
 
 	struct GlobalState *state = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
     global_state_bind( state );
@@ -351,6 +355,8 @@ SM64_LIB_FN void sm64_mario_delete( int32_t marioId )
         DEBUG_PRINT("Tried to delete non-existant Mario with ID: %u", marioId);
         return;
     }
+
+	level_unload_player_loaded_rooms(marioId);
 
     struct GlobalState *globalState = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
     global_state_bind( globalState );
@@ -424,6 +430,7 @@ SM64_LIB_FN void sm64_set_mario_action(int32_t marioId, uint32_t action)
 {
 	struct GlobalState *globalState = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
     global_state_bind( globalState );
+	level_set_active_mario(marioId);
 	
 	set_mario_action( gMarioState, action, 0);
 }
@@ -432,6 +439,7 @@ SM64_LIB_FN void sm64_set_mario_action_arg(int32_t marioId, uint32_t action, uin
 {
 	struct GlobalState *globalState = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
     global_state_bind( globalState );
+	level_set_active_mario(marioId);
 	
 	set_mario_action( gMarioState, action, actionArg);
 }
@@ -440,6 +448,7 @@ SM64_LIB_FN void sm64_set_mario_animation(int32_t marioId, int32_t animID)
 {
 	struct GlobalState *globalState = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
     global_state_bind( globalState );
+	level_set_active_mario(marioId);
 	
 	set_mario_animation(gMarioState, animID);
 }
@@ -490,6 +499,7 @@ SM64_LIB_FN void sm64_mario_take_damage(int32_t marioId, uint32_t damage, uint32
 {
 	struct GlobalState *globalState = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
     global_state_bind( globalState );
+	level_set_active_mario(marioId);
 	
 	fake_damage_knock_back(gMarioState, damage, subtype, x, y, z);
 }
@@ -530,6 +540,7 @@ SM64_LIB_FN void sm64_mario_interact_cap(int32_t marioId, uint32_t capFlag, uint
 {
 	struct GlobalState *globalState = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
     global_state_bind( globalState );
+	level_set_active_mario(marioId);
 	
 	uint16_t capMusic = 0;
 	if(gMarioState->action != ACT_GETTING_BLOWN && capFlag != 0)
@@ -577,13 +588,14 @@ SM64_LIB_FN bool sm64_mario_attack(int32_t marioId, float x, float y, float z, f
 {
 	struct GlobalState *globalState = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
     global_state_bind( globalState );
+	level_set_active_mario(marioId);
 	
 	return fake_interact_bounce_top(gMarioState, x, y, z, hitboxHeight);
 }
 
 SM64_LIB_FN uint32_t sm64_surface_object_create( const struct SM64SurfaceObject *surfaceObject )
 {
-    uint32_t id = level_create_dynamic_object( surfaceObject );
+    uint32_t id = level_load_dynamic_object( surfaceObject );
     return id;
 }
 
@@ -605,7 +617,7 @@ SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId )
             state->mgMarioObject->platform = NULL;
     }
 
-    level_remove_dynamic_object( objectId );
+    level_unload_dynamic_object( objectId, true );
 }
 
 SM64_LIB_FN void sm64_seq_player_play_sequence(uint8_t player, uint8_t seqId, uint16_t arg2)
@@ -699,63 +711,40 @@ void* audio_thread(void* keepAlive)
 void copy_debug_collision_surface(struct SM64DebugSurface *dst, struct Surface *src)
 {
 	if( src && src->isValid ) {
-		vec3i_copy(dst->v1, src->vertex1);
-		vec3i_copy(dst->v2, src->vertex2);
-		vec3i_copy(dst->v3, src->vertex3);
-		dst->normaly = src->normal.y;
-		dst->surfacePointer = (uintptr_t)src;
-		dst->color = src->room;
+		vec3i2f_copy(dst->v1, src->vertex1);
+		vec3i2f_copy(dst->v2, src->vertex2);
+		vec3i2f_copy(dst->v3, src->vertex3);
+		dst->color = src->eSurfaceType;
+		dst->valid = true;
 	}
 	else
 	{
-		vec3i_reset(dst->v1, 0);
-		vec3i_reset(dst->v2, 0);
-		vec3i_reset(dst->v3, 0);
-		dst->normaly=0.0f;
-		dst->surfacePointer = (uintptr_t)src;
+		vec3f_reset(dst->v1, 0);
+		vec3f_reset(dst->v2, 0);
+		vec3f_reset(dst->v3, 0);
+		dst->color = 0;
+		dst->valid = false;
 	}	
 }
 
-struct SM64DebugSurface *sm64_get_collision_surfaces(struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall, int *collidersCount)
+struct SM64DebugSurface *sm64_get_collision_surfaces(int marioId, struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall, int *allSurfacesCount)
 {
-	if(floor->surfacePointer != (uintptr_t) gMarioState->floor )
-	{
-		copy_debug_collision_surface(floor, gMarioState->floor);
+	level_set_active_mario(marioId);
+
+	copy_debug_collision_surface(floor, gMarioState->floor);
+	copy_debug_collision_surface(wall, gMarioState->wall);
+	copy_debug_collision_surface(ceiling, gMarioState->ceil);
+	
+
+	struct Surface **surfaces = level_get_all_loaded_surfaces(allSurfacesCount);
+
+	struct SM64DebugSurface *result = (struct SM64DebugSurface*)malloc(sizeof(struct SM64DebugSurface)*(*allSurfacesCount));
+
+	for(int i=0; i<(*allSurfacesCount); i++) {
+		copy_debug_collision_surface(&(result[i]), surfaces[i]);
 	}
 
-	if(wall->surfacePointer != (uintptr_t) gMarioState->wall )
-	{
-		copy_debug_collision_surface(wall, gMarioState->wall);
-	}
-
-	if(ceiling->surfacePointer != (uintptr_t) gMarioState->ceil ){
-		copy_debug_collision_surface(ceiling, gMarioState->ceil);
-	}
-
-	struct Surface **colliders = get_dynamic_geometry(collidersCount);
-
-	struct SM64DebugSurface *result = (struct SM64DebugSurface*)malloc(sizeof(struct SM64DebugSurface)*(*collidersCount));
-
-	for(int i=0; i<(*collidersCount); i++) {
-		copy_debug_collision_surface(&(result[i]), colliders[i]);
-	}
-
-	free(colliders);
-
-	return result;
-}
-
-struct SM64DebugSurface *sm64_get_all_surfaces(int *surfacesCount)
-{
-	struct Surface **allSurfaces = get_all_geometry(surfacesCount);
-
-	struct SM64DebugSurface *result = (struct SM64DebugSurface*)malloc(sizeof(struct SM64DebugSurface)*(*surfacesCount));
-
-	for(int i=0; i<(*surfacesCount); i++) {
-		copy_debug_collision_surface(&(result[i]), allSurfaces[i]);
-	}
-
-	free(allSurfaces);
+	free(surfaces);
 
 	return result;
 }
@@ -780,12 +769,17 @@ void sm64_level_unload_room(uint32_t roomId)
 	level_unload_room(roomId);
 }
 
-void sm64_level_update_loaded_rooms_list(int *loadedRooms, int loadedCount)
+void sm64_level_update_loaded_rooms_list(int marioId, int *loadedRooms, int loadedCount)
 {
-	level_update_loaded_rooms_list(loadedRooms, loadedCount);
+	level_update_player_loaded_Rooms(marioId, loadedRooms, loadedCount);
 }
 
 void sm64_level_rooms_switch(int switchedRooms[][2], int switchedRoomsCount)
 {
 	level_rooms_switch(switchedRooms, switchedRoomsCount);
+}
+
+void sm64_level_set_active_mario(int marioId)
+{
+	level_set_active_mario(marioId);
 }

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -150,7 +150,8 @@ extern SM64_LIB_FN void sm64_play_sound(int32_t soundBits, float *pos);
 extern SM64_LIB_FN void sm64_play_sound_global(int32_t soundBits);
 extern SM64_LIB_FN int sm64_get_version();
 
-extern SM64_LIB_FN struct SM64DebugSurface *sm64_get_collision_surfaces(int marioId, struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall, int *allSurfacesCount);
+extern SM64_LIB_FN void sm64_get_collision_surfaces(int marioId, struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall, struct SM64DebugSurface surfaces[]);
+extern SM64_LIB_FN int sm64_get_collision_surfaces_count(int marioId);
 
 void audio_tick();
 void* audio_thread(void* param);

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -179,5 +179,7 @@ extern SM64_LIB_FN void sm64_level_init(uint32_t roomsCount);
 extern SM64_LIB_FN void sm64_level_unload();
 extern SM64_LIB_FN void sm64_level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces, const struct SM64SurfaceObject *staticObjects, uint32_t staticObjectsCount);
 extern SM64_LIB_FN void sm64_level_unload_room(uint32_t roomId);
+extern SM64_LIB_FN void sm64_level_update_loaded_rooms_list(int *loadedRooms, int loadedCount);
+extern SM64_LIB_FN void sm64_level_rooms_switch(int switchedRooms[][2], int switchedRoomsCount);
 
 #endif//LIB_SM64_H

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -17,21 +17,12 @@
     #define SM64_LIB_FN
 #endif
 
-// enum SM64ExternalSurfaceType
-// {
-//     floor,
-//     door,
-//     trapdoor,
-//     static_object
-// };
-
 struct SM64Surface
 {
     int16_t type;
     int16_t force;
     uint16_t terrain;
     int32_t vertices[3][3];
-    //enum SM64ExternalSurfaceType externalType;
 };
 
 struct SM64MarioInputs
@@ -106,16 +97,6 @@ struct SM64AnimInfo
 	int32_t animAccel;
 };
 
-struct SM64DebugSurface
-{
-    int v1[3];
-    int v2[3];
-    int v3[3];
-    float normaly;
-    uintptr_t surfacePointer;
-    int color;
-};
-
 typedef void (*SM64DebugPrintFunctionPtr)( const char * );
 
 enum
@@ -128,8 +109,8 @@ enum
 extern SM64_LIB_FN void sm64_global_init( uint8_t *rom, uint8_t *outTexture, SM64DebugPrintFunctionPtr debugPrintFunction );
 extern SM64_LIB_FN void sm64_global_terminate( void );
 
-extern SM64_LIB_FN int32_t sm64_mario_create( float x, float y, float z, int16_t rx, int16_t ry, int16_t rz, uint8_t fake );
-extern SM64_LIB_FN void sm64_mario_tick( int32_t marioId, const struct SM64MarioInputs *inputs, struct SM64MarioState *outState, struct SM64MarioGeometryBuffers *outBuffers );
+extern SM64_LIB_FN int32_t sm64_mario_create( float x, float y, float z, int16_t rx, int16_t ry, int16_t rz, uint8_t fake, int *loadedRooms, int loadedCount);
+extern SM64_LIB_FN void sm64_mario_tick(int32_t marioId, const struct SM64MarioInputs *inputs, struct SM64MarioState *outState, struct SM64MarioGeometryBuffers *outBuffers );
 extern SM64_LIB_FN struct SM64AnimInfo* sm64_mario_get_anim_info( int32_t marioId, int16_t rot[3] );
 extern SM64_LIB_FN void sm64_mario_anim_tick( int32_t marioId, uint32_t stateFlags, struct SM64AnimInfo* animInfo, struct SM64MarioGeometryBuffers *outBuffers, int16_t rot[3] );
 extern SM64_LIB_FN void sm64_mario_delete( int32_t marioId );
@@ -169,8 +150,7 @@ extern SM64_LIB_FN void sm64_play_sound(int32_t soundBits, float *pos);
 extern SM64_LIB_FN void sm64_play_sound_global(int32_t soundBits);
 extern SM64_LIB_FN int sm64_get_version();
 
-extern SM64_LIB_FN struct SM64DebugSurface *sm64_get_collision_surfaces(struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall, int *collidersCount);
-extern SM64_LIB_FN struct SM64DebugSurface *sm64_get_all_surfaces(int *surfacesCount);
+extern SM64_LIB_FN struct SM64DebugSurface *sm64_get_collision_surfaces(int marioId, struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall, int *allSurfacesCount);
 
 void audio_tick();
 void* audio_thread(void* param);
@@ -179,7 +159,8 @@ extern SM64_LIB_FN void sm64_level_init(uint32_t roomsCount);
 extern SM64_LIB_FN void sm64_level_unload();
 extern SM64_LIB_FN void sm64_level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces, const struct SM64SurfaceObject *staticObjects, uint32_t staticObjectsCount);
 extern SM64_LIB_FN void sm64_level_unload_room(uint32_t roomId);
-extern SM64_LIB_FN void sm64_level_update_loaded_rooms_list(int *loadedRooms, int loadedCount);
+extern SM64_LIB_FN void sm64_level_update_loaded_rooms_list(int marioId, int *loadedRooms, int loadedCount);
 extern SM64_LIB_FN void sm64_level_rooms_switch(int switchedRooms[][2], int switchedRoomsCount);
+extern SM64_LIB_FN void level_set_active_mario(int marioId);
 
 #endif//LIB_SM64_H

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include "decomp/include/external_types.h"
 
 #ifdef _WIN32
     #ifdef SM64_LIB_EXPORT
@@ -112,6 +113,7 @@ struct SM64DebugSurface
     int v3[3];
     float normaly;
     uintptr_t surfacePointer;
+    int color;
 };
 
 typedef void (*SM64DebugPrintFunctionPtr)( const char * );
@@ -177,7 +179,7 @@ void* audio_thread(void* param);
 
 extern SM64_LIB_FN void sm64_level_init(uint32_t roomsCount);
 extern SM64_LIB_FN void sm64_level_unload();
-extern SM64_LIB_FN void sm64_level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces);
+extern SM64_LIB_FN void sm64_level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces, const struct SM64SurfaceObject *staticObjects, uint32_t staticObjectsCount);
 extern SM64_LIB_FN void sm64_level_unload_room(uint32_t roomId);
 
 #endif//LIB_SM64_H

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -169,7 +169,7 @@ extern SM64_LIB_FN void sm64_play_sound(int32_t soundBits, float *pos);
 extern SM64_LIB_FN void sm64_play_sound_global(int32_t soundBits);
 extern SM64_LIB_FN int sm64_get_version();
 
-extern SM64_LIB_FN void sm64_get_collision_surfaces(struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall);
+extern SM64_LIB_FN struct SM64DebugSurface *sm64_get_collision_surfaces(struct SM64DebugSurface *floor, struct SM64DebugSurface *ceiling, struct SM64DebugSurface *wall, int *collidersCount);
 extern SM64_LIB_FN struct SM64DebugSurface *sm64_get_all_surfaces(int *surfacesCount);
 
 void audio_tick();

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -128,8 +128,6 @@ enum
 extern SM64_LIB_FN void sm64_global_init( uint8_t *rom, uint8_t *outTexture, SM64DebugPrintFunctionPtr debugPrintFunction );
 extern SM64_LIB_FN void sm64_global_terminate( void );
 
-//extern SM64_LIB_FN void sm64_static_surfaces_load( const struct SM64Surface *surfaceArray, uint32_t numSurfaces );
-
 extern SM64_LIB_FN int32_t sm64_mario_create( float x, float y, float z, int16_t rx, int16_t ry, int16_t rz, uint8_t fake );
 extern SM64_LIB_FN void sm64_mario_tick( int32_t marioId, const struct SM64MarioInputs *inputs, struct SM64MarioState *outState, struct SM64MarioGeometryBuffers *outBuffers );
 extern SM64_LIB_FN struct SM64AnimInfo* sm64_mario_get_anim_info( int32_t marioId, int16_t rot[3] );
@@ -158,9 +156,9 @@ extern SM64_LIB_FN void sm64_mario_kill(int32_t marioId);
 extern SM64_LIB_FN void sm64_mario_interact_cap(int32_t marioId, uint32_t capFlag, uint16_t capTime, uint8_t playMusic);
 extern SM64_LIB_FN bool sm64_mario_attack(int32_t marioId, float x, float y, float z, float hitboxHeight);
 
-// extern SM64_LIB_FN uint32_t sm64_surface_object_create( const struct SM64SurfaceObject *surfaceObject );
-// extern SM64_LIB_FN void sm64_surface_object_move( uint32_t objectId, const struct SM64ObjectTransform *transform );
-// extern SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId );
+extern SM64_LIB_FN uint32_t sm64_surface_object_create( const struct SM64SurfaceObject *surfaceObject );
+extern SM64_LIB_FN void sm64_surface_object_move( uint32_t objectId, const struct SM64ObjectTransform *transform );
+extern SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId );
 
 extern SM64_LIB_FN void sm64_seq_player_play_sequence(uint8_t player, uint8_t seqId, uint16_t arg2);
 extern SM64_LIB_FN void sm64_play_music(uint8_t player, uint16_t seqArgs, uint16_t fadeTimer);

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -16,12 +16,21 @@
     #define SM64_LIB_FN
 #endif
 
+// enum SM64ExternalSurfaceType
+// {
+//     floor,
+//     door,
+//     trapdoor,
+//     static_object
+// };
+
 struct SM64Surface
 {
     int16_t type;
     int16_t force;
     uint16_t terrain;
     int32_t vertices[3][3];
+    //enum SM64ExternalSurfaceType externalType;
 };
 
 struct SM64MarioInputs
@@ -29,19 +38,6 @@ struct SM64MarioInputs
     float camLookX, camLookZ;
     float stickX, stickY;
     uint8_t buttonA, buttonB, buttonZ;
-};
-
-struct SM64ObjectTransform
-{
-    float position[3];
-    float eulerRotation[3];
-};
-
-struct SM64SurfaceObject
-{
-    struct SM64ObjectTransform transform;
-    uint32_t surfaceCount;
-    struct SM64Surface *surfaces;
 };
 
 struct SM64MarioState
@@ -130,7 +126,7 @@ enum
 extern SM64_LIB_FN void sm64_global_init( uint8_t *rom, uint8_t *outTexture, SM64DebugPrintFunctionPtr debugPrintFunction );
 extern SM64_LIB_FN void sm64_global_terminate( void );
 
-extern SM64_LIB_FN void sm64_static_surfaces_load( const struct SM64Surface *surfaceArray, uint32_t numSurfaces );
+//extern SM64_LIB_FN void sm64_static_surfaces_load( const struct SM64Surface *surfaceArray, uint32_t numSurfaces );
 
 extern SM64_LIB_FN int32_t sm64_mario_create( float x, float y, float z, int16_t rx, int16_t ry, int16_t rz, uint8_t fake );
 extern SM64_LIB_FN void sm64_mario_tick( int32_t marioId, const struct SM64MarioInputs *inputs, struct SM64MarioState *outState, struct SM64MarioGeometryBuffers *outBuffers );
@@ -160,9 +156,9 @@ extern SM64_LIB_FN void sm64_mario_kill(int32_t marioId);
 extern SM64_LIB_FN void sm64_mario_interact_cap(int32_t marioId, uint32_t capFlag, uint16_t capTime, uint8_t playMusic);
 extern SM64_LIB_FN bool sm64_mario_attack(int32_t marioId, float x, float y, float z, float hitboxHeight);
 
-extern SM64_LIB_FN uint32_t sm64_surface_object_create( const struct SM64SurfaceObject *surfaceObject );
-extern SM64_LIB_FN void sm64_surface_object_move( uint32_t objectId, const struct SM64ObjectTransform *transform );
-extern SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId );
+// extern SM64_LIB_FN uint32_t sm64_surface_object_create( const struct SM64SurfaceObject *surfaceObject );
+// extern SM64_LIB_FN void sm64_surface_object_move( uint32_t objectId, const struct SM64ObjectTransform *transform );
+// extern SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId );
 
 extern SM64_LIB_FN void sm64_seq_player_play_sequence(uint8_t player, uint8_t seqId, uint16_t arg2);
 extern SM64_LIB_FN void sm64_play_music(uint8_t player, uint16_t seqArgs, uint16_t fadeTimer);
@@ -178,5 +174,10 @@ extern SM64_LIB_FN struct SM64DebugSurface *sm64_get_all_surfaces(int *surfacesC
 
 void audio_tick();
 void* audio_thread(void* param);
+
+extern SM64_LIB_FN void sm64_level_init(uint32_t roomsCount);
+extern SM64_LIB_FN void sm64_level_unload();
+extern SM64_LIB_FN void sm64_level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces);
+extern SM64_LIB_FN void sm64_level_unload_room(uint32_t roomId);
 
 #endif//LIB_SM64_H

--- a/src/load_surfaces.c
+++ b/src/load_surfaces.c
@@ -442,9 +442,14 @@ void level_unload_room(uint32_t roomId)
 
     if( room->staticObjectSurfaces != NULL )
     {
-        if(room->staticObjectSurfaces->transform!=NULL)
+        struct SurfaceObjectTransform *previousTransform=NULL;
+        for(int i=0; i<room->staticObjectSurfacesCount; i++)
         {
-            free(room->staticObjectSurfaces->transform);
+            if(room->staticObjectSurfaces[i].transform!=NULL && room->staticObjectSurfaces[i].transform != previousTransform)
+            {
+                previousTransform = room->staticObjectSurfaces[i].transform;
+                free(room->staticObjectSurfaces[i].transform);
+            }
         }
         free(room->staticObjectSurfaces);
         room->staticObjectSurfaces = NULL;

--- a/src/load_surfaces.c
+++ b/src/load_surfaces.c
@@ -442,6 +442,10 @@ void level_unload_room(uint32_t roomId)
 
     if( room->staticObjectSurfaces != NULL )
     {
+        if(room->staticObjectSurfaces->transform!=NULL)
+        {
+            free(room->staticObjectSurfaces->transform);
+        }
         free(room->staticObjectSurfaces);
         room->staticObjectSurfaces = NULL;
     }
@@ -497,10 +501,8 @@ void level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, 
 
 
     room->staticObjectSurfacesCount=0;
-    int acc=0;
     for(int i=0; i<staticObjectsCount; i++)
     {
-        acc+=staticObjects[i].surfaceCount;
         room->staticObjectSurfacesCount+=staticObjects[i].surfaceCount;
     }
     room->staticObjectSurfaces = malloc( sizeof( struct Surface ) * room->staticObjectSurfacesCount );
@@ -508,11 +510,11 @@ void level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, 
     uint32_t cIdx=0;
     for(int i=0; i<staticObjectsCount; i++)
     {
-        struct SurfaceObjectTransform transform;
-        init_transform( &transform, &(staticObjects[i].transform) );
+        struct SurfaceObjectTransform *transform = (struct SurfaceObjectTransform*)malloc(sizeof(struct SurfaceObjectTransform));
+        init_transform( transform, &(staticObjects[i].transform) );
         for(int j=0; j<staticObjects[i].surfaceCount;j++)
         {
-            engine_surface_from_lib_surface( &room->staticObjectSurfaces[cIdx], &staticObjects[i].surfaces[j], &transform );
+            engine_surface_from_lib_surface( &room->staticObjectSurfaces[cIdx], &staticObjects[i].surfaces[j], transform );
             room->staticObjectSurfaces[cIdx].room=1;
             cIdx++;
         }

--- a/src/load_surfaces.c
+++ b/src/load_surfaces.c
@@ -11,7 +11,7 @@
 
 #include "debug_print.h"
 
-#define BIG_HACK_FLOOR_HEIGHT 1000
+#define BIG_HACK_FLOOR_HEIGHT 100000
 #define BIG_HACK_FLOOR_DIMENSIONS 1000
 
 static uint32_t s_level_rooms_count = 0;
@@ -57,6 +57,10 @@ void create_big_floor_hack()
 
 void level_update_big_floor_hack(float x, float y, float z)
 {
+    if(s_big_floor_hack1==NULL || s_big_floor_hack2==NULL)
+    {
+        return;
+    }
     int height = y-BIG_HACK_FLOOR_HEIGHT;
 
     s_big_floor_hack1->vertex1[0] = x-BIG_HACK_FLOOR_DIMENSIONS;

--- a/src/load_surfaces.h
+++ b/src/load_surfaces.h
@@ -4,19 +4,75 @@
 #include "decomp/include/external_types.h"
 #include "libsm64.h"
 
-extern void level_init(uint32_t roomsCount);
+
+struct LoadedSurfaceObject
+{
+    struct SurfaceObjectTransform *transform;
+    uint32_t surfaceCount;
+    struct SM64Surface *libSurfaces;
+    struct Surface *engineSurfaces;    
+};
+
+struct Room
+{
+    struct Surface *surfaces;
+    uint32_t count;
+};
+
+struct MarioLoadedRooms
+{
+    int32_t marioId;
+    struct Room **rooms;
+    uint32_t count;
+};
+
+struct DynamicObjects
+{
+    struct LoadedSurfaceObject *objects;
+    uint32_t objectsCount;
+
+    struct Surface **cached_surfaces;
+    uint32_t cached_count;
+};
+
+extern bool level_init(uint32_t roomsCount);
 extern void level_unload();
+extern void level_set_active_mario(int marioId);
+
 extern void level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces, const struct SM64SurfaceObject *staticObjects, uint32_t staticObjectsCount);
-extern void level_unload_room(uint32_t roomId);
-extern void level_update_loaded_rooms_list(int *loadedRooms, int loadedCount);
 extern void level_rooms_switch(int switchedRooms[][2], int switchedRoomsCount);
-extern void level_update_big_floor_hack(float x, float y, float z);
 
-extern uint32_t level_create_dynamic_object( const struct SM64SurfaceObject *surfaceObject );
-extern void level_remove_dynamic_object( uint32_t objId );
-extern struct SurfaceObjectTransform *level_get_dynamic_object_transform( uint32_t objId );
+extern void level_load_player_loaded_rooms(int marioId);
+extern void level_unload_player_loaded_rooms(int marioId);
+extern void level_update_player_loaded_Rooms(int marioId, int *newloadedRooms, int loadedCount);
+
+extern uint32_t level_load_dynamic_object( const struct SM64SurfaceObject *surfaceObject );
+extern void level_unload_dynamic_object( uint32_t objId, bool update_cache );
 extern void level_update_dynamic_object_transform( uint32_t objId, const struct SM64ObjectTransform *newTransform );
+extern struct SurfaceObjectTransform *level_get_dynamic_object_transform( uint32_t objId );
 
-extern uint32_t level_get_all_surface_group_count(void);
-extern uint32_t level_get_all_surface_group_size(uint32_t groupIndex);
-extern struct Surface *level_get_surface_index(uint32_t groupIndex, uint32_t surfaceIndex);
+/**
+ * @brief Gets the number of activated rooms for the current Mario +1 for the dynamic objects.
+ * 
+ * @return uint32_t
+ */
+extern uint32_t level_get_room_count(void);
+/**
+ * @brief Gets the number of surfaces contained by the given selected activated room.
+ * If the roomIndex is the last one it will correspond to the dynamic objects surfaces.
+ * 
+ * @param roomIndex activated room index from which to get the number of surfaces.
+ * @return uint32_t
+ */
+extern uint32_t level_get_room_surfaces_count(uint32_t roomIndex);
+/**
+ * @brief Gets a surface from the given selected activated room.
+ * If the roomIndex is the last one it will correspond to the dynamic objects surfaces.
+ * 
+ * @param roomIndex activated room index from which to get the surface.
+ * @param surfaceIndex surface index to get from the given activated room.
+ * @return struct Surface*
+ */
+extern struct Surface *level_get_room_surface(uint32_t roomIndex, uint32_t surfaceIndex);
+
+extern struct Surface **level_get_all_loaded_surfaces(int *resultCount);

--- a/src/load_surfaces.h
+++ b/src/load_surfaces.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "decomp/include/types.h"
+#include "decomp/include/external_types.h"
 #include "libsm64.h"
 
 // extern uint32_t loaded_surface_iter_group_count( void );
@@ -16,7 +17,7 @@
 
 extern void level_init(uint32_t roomsCount);
 extern void level_unload();
-extern void level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces);
+extern void level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces, const struct SM64SurfaceObject *staticObjects, uint32_t staticObjectsCount);
 extern void level_unload_room(uint32_t roomId);
 
 extern uint32_t level_get_all_surface_group_count(void);

--- a/src/load_surfaces.h
+++ b/src/load_surfaces.h
@@ -20,6 +20,11 @@ extern void level_unload();
 extern void level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces, const struct SM64SurfaceObject *staticObjects, uint32_t staticObjectsCount);
 extern void level_unload_room(uint32_t roomId);
 
+extern uint32_t level_create_dynamic_object( const struct SM64SurfaceObject *surfaceObject );
+extern void level_remove_dynamic_object( uint32_t objId );
+extern struct SurfaceObjectTransform *level_get_dynamic_object_transform( uint32_t objId );
+extern void level_update_dynamic_object_transform( uint32_t objId, const struct SM64ObjectTransform *newTransform );
+
 extern uint32_t level_get_all_surface_group_count(void);
 extern uint32_t level_get_all_surface_group_size(uint32_t groupIndex);
 extern struct Surface *level_get_surface_index(uint32_t groupIndex, uint32_t surfaceIndex);

--- a/src/load_surfaces.h
+++ b/src/load_surfaces.h
@@ -3,13 +3,22 @@
 #include "decomp/include/types.h"
 #include "libsm64.h"
 
-extern uint32_t loaded_surface_iter_group_count( void );
-extern uint32_t loaded_surface_iter_group_size( uint32_t groupIndex );
-extern struct Surface *loaded_surface_iter_get_at_index( uint32_t groupIndex, uint32_t surfaceIndex );
+// extern uint32_t loaded_surface_iter_group_count( void );
+// extern uint32_t loaded_surface_iter_group_size( uint32_t groupIndex );
+// extern struct Surface *loaded_surface_iter_get_at_index( uint32_t groupIndex, uint32_t surfaceIndex );
 
-extern void surfaces_load_static( const struct SM64Surface *surfaceArray, uint32_t numSurfaces );
-extern uint32_t surfaces_load_object( const struct SM64SurfaceObject *surfaceObject );
-extern void surface_object_update_transform( uint32_t objId, const struct SM64ObjectTransform *newTransform );
-extern struct SurfaceObjectTransform *surfaces_object_get_transform_ptr( uint32_t objId );
-extern void surfaces_unload_object( uint32_t objId );
-extern void surfaces_unload_all( void );
+// extern void surfaces_load_static( const struct SM64Surface *surfaceArray, uint32_t numSurfaces );
+// extern uint32_t surfaces_load_object( const struct SM64SurfaceObject *surfaceObject );
+// extern void surface_object_update_transform( uint32_t objId, const struct SM64ObjectTransform *newTransform );
+// extern struct SurfaceObjectTransform *surfaces_object_get_transform_ptr( uint32_t objId );
+// extern void surfaces_unload_object( uint32_t objId );
+// extern void surfaces_unload_all( void );
+
+extern void level_init(uint32_t roomsCount);
+extern void level_unload();
+extern void level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces);
+extern void level_unload_room(uint32_t roomId);
+
+extern uint32_t level_get_all_surface_group_count(void);
+extern uint32_t level_get_all_surface_group_size(uint32_t groupIndex);
+extern struct Surface *level_get_surface_index(uint32_t groupIndex, uint32_t surfaceIndex);

--- a/src/load_surfaces.h
+++ b/src/load_surfaces.h
@@ -4,21 +4,12 @@
 #include "decomp/include/external_types.h"
 #include "libsm64.h"
 
-// extern uint32_t loaded_surface_iter_group_count( void );
-// extern uint32_t loaded_surface_iter_group_size( uint32_t groupIndex );
-// extern struct Surface *loaded_surface_iter_get_at_index( uint32_t groupIndex, uint32_t surfaceIndex );
-
-// extern void surfaces_load_static( const struct SM64Surface *surfaceArray, uint32_t numSurfaces );
-// extern uint32_t surfaces_load_object( const struct SM64SurfaceObject *surfaceObject );
-// extern void surface_object_update_transform( uint32_t objId, const struct SM64ObjectTransform *newTransform );
-// extern struct SurfaceObjectTransform *surfaces_object_get_transform_ptr( uint32_t objId );
-// extern void surfaces_unload_object( uint32_t objId );
-// extern void surfaces_unload_all( void );
-
 extern void level_init(uint32_t roomsCount);
 extern void level_unload();
 extern void level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces, const struct SM64SurfaceObject *staticObjects, uint32_t staticObjectsCount);
 extern void level_unload_room(uint32_t roomId);
+extern void level_update_loaded_rooms_list(int *loadedRooms, int loadedCount);
+extern void level_rooms_switch(int switchedRooms[][2], int switchedRoomsCount);
 
 extern uint32_t level_create_dynamic_object( const struct SM64SurfaceObject *surfaceObject );
 extern void level_remove_dynamic_object( uint32_t objId );

--- a/src/load_surfaces.h
+++ b/src/load_surfaces.h
@@ -10,6 +10,7 @@ extern void level_load_room(uint32_t roomId, const struct SM64Surface *staticSur
 extern void level_unload_room(uint32_t roomId);
 extern void level_update_loaded_rooms_list(int *loadedRooms, int loadedCount);
 extern void level_rooms_switch(int switchedRooms[][2], int switchedRoomsCount);
+extern void level_update_big_floor_hack(float x, float y, float z);
 
 extern uint32_t level_create_dynamic_object( const struct SM64SurfaceObject *surfaceObject );
 extern void level_remove_dynamic_object( uint32_t objId );


### PR DESCRIPTION
Now it supports a brand new way of managing the loaded geometry to sm64. Api has changed so don't update the submodule on open lara before adding the required changes there.

Every single room is loaded on the start of the level and divided by rooms (that correspond to tomb raider rooms). All dynamic objects are treated as a separate extra room. Each room has both static surfaces and static meshes merged in the same array since there's no benefit for having them separated and having them merged simplifies the management. 

If a flip is made in tomb raider we simply switch the rooms in the array the same way open lara does. Avoids having to reload room data in SM64.

Every frame a big plane is updated underneath mario to allow him to jump over places without loaded geometry bellow.

Every "Mario" has it's own array of activated rooms so they don't interfere with  each other when loading rooms. This avoids a mario activating a different overlapping room where other player is. This also includes the doppelganger.

Each surface is now tag with it's origin type (static surface, static mesh, etc) for the visual debugger.

New streamlined debugger geometry export with less conversions and hoops.

Added VScode config files to work directly with this submodule and launch open lara with debugger without having to compile it (for faster code iterations on the submodule).

Added room management console messages with the usage of DEBUG_LEVEL_ROOMS on the compiler.

