### PR TITLE
Added clipper boxes support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "makefile.extensionOutputFolder": "./.vscode",
     "files.associations": {
         "external_types.h": "c",
-        "functional": "c"
+        "functional": "c",
+        "external.h": "c"
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ default: lib
 
 CC      := gcc
 CXX 	:= g++
-CFLAGS  := -g -Wall -fPIC -DSM64_LIB_EXPORT -DVERSION_US -DNO_SEGMENTED_MEMORY -DGBI_FLOATS -DDEBUG_LEVEL_ROOMS
+CFLAGS  := -g -Wall -fPIC -DSM64_LIB_EXPORT -DVERSION_US -DNO_SEGMENTED_MEMORY -DGBI_FLOATS -DDEBUG_LEVEL_ROOMS -Wno-unknown-pragmas
 LDFLAGS := -g -lm -shared -lpthread
 ENDFLAGS := -g -fPIC
 ifeq ($(OS),Windows_NT)

--- a/src/decomp/engine/surface_collision.c
+++ b/src/decomp/engine/surface_collision.c
@@ -3,54 +3,6 @@
 #include "../include/surface_terrains.h"
 #include "../../load_surfaces.h"
 
-struct Surface **get_all_geometry(int *count){
-
-    uint32_t numberOfSurfaces=0;
-
-    uint32_t groupCount = level_get_room_count();
-    for( int i = 0; i < groupCount-1; ++i ) {
-        uint32_t surfCount = level_get_room_surfaces_count( i );
-        numberOfSurfaces+=surfCount;
-    }
-
-    struct Surface **allSurfaces = (struct Surface **)malloc(sizeof(struct Surface *)*numberOfSurfaces);
-
-    uint32_t sindex=0;
-    for( int i = 0; i < groupCount-1; ++i ) {
-        uint32_t surfCount = level_get_room_surfaces_count( i );
-        for( int j = 0; j < surfCount; ++j ) {
-            struct Surface * ls = level_get_room_surface( i, j );
-            if(i>=(groupCount-1)/2)
-            {
-                ls->room=1;
-            }
-            allSurfaces[sindex]=ls;
-            sindex++;
-        }
-    }
-
-    *count=numberOfSurfaces;
-    return allSurfaces;
-}
-
-struct Surface **get_dynamic_geometry(int *count){
-
-    uint32_t groupCount = level_get_room_count();
-    uint32_t numberOfSurfaces = level_get_room_surfaces_count( groupCount-1 );
-
-    struct Surface **dynamicSurfaces = (struct Surface **)malloc(sizeof(struct Surface *)*numberOfSurfaces);
-
-    for( int i = 0; i < numberOfSurfaces; i++ ) {
-        struct Surface * ls = level_get_room_surface( groupCount-1, i );
-        ls->room=2;
-        dynamicSurfaces[i]=ls;
-    }
-    
-
-    *count=numberOfSurfaces;
-    return dynamicSurfaces;
-}
-
 /**
  * Iterate through the list of ceilings and find the first ceiling over a given point.
  */

--- a/src/decomp/engine/surface_collision.h
+++ b/src/decomp/engine/surface_collision.h
@@ -40,7 +40,5 @@ f32 find_floor_height(f32 x, f32 y, f32 z);
 f32 find_floor(f32 xPos, f32 yPos, f32 zPos, struct Surface **pfloor);
 f32 find_water_level(f32 x, f32 z);
 f32 find_poison_gas_level(f32 x, f32 z);
-struct Surface **get_all_geometry(int *count);
-struct Surface **get_dynamic_geometry(int *count);
 
 #endif // SURFACE_COLLISION_H

--- a/src/decomp/include/external_types.h
+++ b/src/decomp/include/external_types.h
@@ -4,6 +4,30 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/**
+ * @brief The max number of clipper blocks in range. We probably won't find more than this activated at once.
+ * (famous last words) 
+ */
+#define MAX_CLIPPER_BLOCKS 50
+/**
+ * @brief each clipper block is a cube made of triangles
+ */
+#define MAX_CLIPPER_BLOCKS_FACES 6*2*MAX_CLIPPER_BLOCKS
+/**
+ * @brief each block replaces 2 faces overlapping. 
+ */
+#define MAX_CLIPPED_FACES 2*MAX_CLIPPER_BLOCKS
+
+struct SM64Surface
+{
+    int16_t type;
+    int16_t force;
+    uint16_t terrain;
+    int roomIndex; // original room index necessary for face clipper blocks 
+    int faceIndex; // original face index in room necessary for face clipper blocks 
+    int32_t vertices[3][3];
+};
+
 struct SM64ObjectTransform
 {
     float position[3];
@@ -22,7 +46,8 @@ enum SM64ExternalSurfaceTypes
     EXTERNAL_SURFACE_TYPE_STATIC_SURFACE,
     EXTERNAL_SURFACE_TYPE_STATIC_MESH,
     EXTERNAL_SURFACE_TYPE_DYNAMIC_OBJECT,
-    EXTERNAL_SURFACE_TYPE_FLOOR_HACK
+    EXTERNAL_SURFACE_TYPE_FLOOR_HACK,
+    EXTERNAL_SURFACE_TYPE_WALL_CLIPPER
 };
 
 struct SM64DebugSurface
@@ -30,10 +55,10 @@ struct SM64DebugSurface
     float v1[3];
     float v2[3];
     float v3[3];
-    //float normaly;
-    //uintptr_t surfacePointer;
     enum SM64ExternalSurfaceTypes color;
     bool valid;
 };
+
+
 
 #endif

--- a/src/decomp/include/external_types.h
+++ b/src/decomp/include/external_types.h
@@ -23,8 +23,6 @@ struct SM64Surface
     int16_t type;
     int16_t force;
     uint16_t terrain;
-    int roomIndex; // original room index necessary for face clipper blocks 
-    int faceIndex; // original face index in room necessary for face clipper blocks 
     int32_t vertices[3][3];
 };
 

--- a/src/decomp/include/external_types.h
+++ b/src/decomp/include/external_types.h
@@ -8,7 +8,7 @@
  * @brief The max number of clipper blocks in range. We probably won't find more than this activated at once.
  * (famous last words) 
  */
-#define MAX_CLIPPER_BLOCKS 50
+#define MAX_CLIPPER_BLOCKS 200
 /**
  * @brief each clipper block is a cube made of triangles
  */

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -787,6 +787,11 @@ void sm64_level_update_loaded_rooms_list(int marioId, int *loadedRooms, int load
 	level_update_player_loaded_Rooms(marioId, loadedRooms, loadedCount);
 }
 
+void sm64_level_update_player_loaded_Rooms_with_clippers(int marioId, int *newloadedRooms, int loadedCount, const struct SM64Surface clippers[MAX_CLIPPER_BLOCKS_FACES], uint32_t clippersCount)
+{
+	level_update_player_loaded_Rooms_with_clippers(marioId, newloadedRooms, loadedCount, clippers, clippersCount);
+}
+
 void sm64_level_rooms_switch(int switchedRooms[][2], int switchedRoomsCount)
 {
 	level_rooms_switch(switchedRooms, switchedRoomsCount);

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -17,14 +17,6 @@
     #define SM64_LIB_FN
 #endif
 
-struct SM64Surface
-{
-    int16_t type;
-    int16_t force;
-    uint16_t terrain;
-    int32_t vertices[3][3];
-};
-
 struct SM64MarioInputs
 {
     float camLookX, camLookZ;
@@ -161,6 +153,7 @@ extern SM64_LIB_FN void sm64_level_unload();
 extern SM64_LIB_FN void sm64_level_load_room(uint32_t roomId, const struct SM64Surface *staticSurfaces, uint32_t numSurfaces, const struct SM64SurfaceObject *staticObjects, uint32_t staticObjectsCount);
 extern SM64_LIB_FN void sm64_level_unload_room(uint32_t roomId);
 extern SM64_LIB_FN void sm64_level_update_loaded_rooms_list(int marioId, int *loadedRooms, int loadedCount);
+extern SM64_LIB_FN void sm64_level_update_player_loaded_Rooms_with_clippers(int marioId, int *newloadedRooms, int loadedCount, const struct SM64Surface clippers[MAX_CLIPPER_BLOCKS_FACES], uint32_t clippersCount);
 extern SM64_LIB_FN void sm64_level_rooms_switch(int switchedRooms[][2], int switchedRoomsCount);
 extern SM64_LIB_FN void level_set_active_mario(int marioId);
 

--- a/src/load_surfaces.h
+++ b/src/load_surfaces.h
@@ -22,8 +22,12 @@ struct Room
 struct MarioLoadedRooms
 {
     int32_t marioId;
+    
     struct Room **rooms;
     uint32_t count;
+    
+    struct Surface clippers[MAX_CLIPPER_BLOCKS_FACES];
+    uint32_t clippersCount;
 };
 
 struct DynamicObjects
@@ -45,6 +49,7 @@ extern void level_rooms_switch(int switchedRooms[][2], int switchedRoomsCount);
 extern void level_load_player_loaded_rooms(int marioId);
 extern void level_unload_player_loaded_rooms(int marioId);
 extern void level_update_player_loaded_Rooms(int marioId, int *newloadedRooms, int loadedCount);
+extern void level_update_player_loaded_Rooms_with_clippers(int marioId, int *newloadedRooms, int loadedCount, const struct SM64Surface clippers[MAX_CLIPPER_BLOCKS_FACES], uint32_t clippersCount);
 
 extern uint32_t level_load_dynamic_object( const struct SM64SurfaceObject *surfaceObject );
 extern void level_unload_dynamic_object( uint32_t objId, bool update_cache );


### PR DESCRIPTION
Each player can now have an array of surfaces with boxes that block them from clipping through 1 face thin walls. These surfaces are updated with the call for updating the player visible rooms.