### PR TITLE
Mario will now grabs all ledges and shimmies based on mario's perspective.

### DIFF
--- a/src/decomp/game/mario.c
+++ b/src/decomp/game/mario.c
@@ -1311,6 +1311,7 @@ void update_mario_joystick_inputs(struct MarioState *m) {
 
     if (m->intendedMag > 0.0f) {
         m->intendedYaw = atan2s(-controller->stickY, controller->stickX) + m->area->camera->yaw;
+        m->rawYaw = atan2s(-controller->stickY, controller->stickX);
         m->input |= INPUT_NONZERO_ANALOG;
     } else {
         m->intendedYaw = m->faceAngle[1];
@@ -1326,7 +1327,9 @@ void update_mario_geometry_inputs(struct MarioState *m) {
 
     // We want to allow Mario to be able to climb the same steps lara would. 
     // We will only retain big wall check and increase it's displacement to 65 units to allow Mario to reach the same height.
-    f32_find_wall_collision(&m->pos[0], &m->pos[1], &m->pos[2], 65.0f, 50.0f);
+    // We also don't want to check for wall collision if we are shimmying.
+    if( m->action != ACT_LEDGE_GRAB )
+        f32_find_wall_collision(&m->pos[0], &m->pos[1], &m->pos[2], 65.0f, 50.0f);
     //f32_find_wall_collision(&m->pos[0], &m->pos[1], &m->pos[2], 30.0f, 24.0f);
 
     m->floorHeight = find_floor(m->pos[0], m->pos[1], m->pos[2], &m->floor);

--- a/src/decomp/game/mario_actions_automatic.c
+++ b/src/decomp/game/mario_actions_automatic.c
@@ -587,22 +587,25 @@ s32 act_ledge_grab(struct MarioState *m) {
     if (m->actionTimer == 10 && (m->input & INPUT_NONZERO_ANALOG))
 #endif
     {
-        // We need to determine if the player intends to shimmy, climb or fall down with the direction inputs.
-        // These are the tolerance intervals for shimmy action since the camera can float by a lot.
-        // Widening the angles will make it easier to remain in shimmy action at extreme camera angles
-        // but will make it harder for the player to climb up or down.
-        if( (intendedDYaw <= -0x2000 && intendedDYaw >= -0x6000) || (intendedDYaw <= 0x6000 && intendedDYaw >= 0x2000) ) {
-            // Shimmy time!
+        // Since tomb raider rotates the camera a lot we need to use the raw inputs to choose the action.
+        // Left goes to mario's own left, right to mario's own right, up to climb up and down to go down.
+        // This is regardless of camera orientation.
+        if( m->rawYaw <= -0x2000 && m->rawYaw >= -0x6000 ) 
+        {
+            // Shimmy left!
             shimmy = true;
-
-            // We need to determine which way is left direction from the camera perspective.
-            bool left = (m->faceAngle[1] >= 0 && intendedDYaw >= 0) || (m->faceAngle[1] < 0 && intendedDYaw >= 0);
-
-            m->pos[0] += coss(m->faceAngle[1]) * ( left ? shimmyVelocity : -shimmyVelocity );
-            m->pos[2] += sins(m->faceAngle[1]) * ( left ? -shimmyVelocity : shimmyVelocity );
+            m->pos[0] += coss(m->faceAngle[1]) * -shimmyVelocity;
+            m->pos[2] += sins(m->faceAngle[1]) * shimmyVelocity;        
+        }
+        else if(m->rawYaw <= 0x6000 && m->rawYaw >= 0x2000)
+        {
+            // Shimmy right!
+            shimmy = true;
+            m->pos[0] += coss(m->faceAngle[1]) * shimmyVelocity;
+            m->pos[2] += sins(m->faceAngle[1]) * -shimmyVelocity;
         }
         // If the angle is outside of shimmy but clearly up front then we try to trigger the edge climbing action.
-        else if (intendedDYaw >= -0x4000 && intendedDYaw <= 0x4000) {
+        else if (m->rawYaw >= -0x4000 && m->rawYaw <= 0x4000) {
             if (hasSpaceForMario) {
                 return set_mario_action(m, ACT_LEDGE_CLIMB_SLOW_1, 0);
             }

--- a/src/decomp/include/types.h
+++ b/src/decomp/include/types.h
@@ -369,6 +369,7 @@ struct MarioState
 	u16 overrideTerrain; // libsm64-gmod: added field
 	s16 overrideFloorType; // libsm64-gmod: added field
 	u8 fallDamage; // libsm64 tomb raider: added field
+	s16 rawYaw; // libsm64 tomb raider: added field
 };
 
 #endif // TYPES_H


### PR DESCRIPTION
Removed a wall check when at ACT_LEDGE_GRAB state to allow him to shimmy on ledges with low ceilings. The quarter step algorithm still will block Mario from shimmy into a side wall.

Shimmy controls were changed to be in mario's own perspective and not camera perspective since tomb raider's camera moves a lot (sometimes even to the oposite side) which would make controlling the shimmy a nightmare.

This fixes https://github.com/headshot2017/OpenLara/issues/14