### PR TITLE
Implemented new submerged swimming logic.

### DIFF
--- a/src/decomp/game/mario.h
+++ b/src/decomp/game/mario.h
@@ -29,6 +29,7 @@ void mario_set_forward_vel(struct MarioState *m, f32 speed);
 s32 mario_get_floor_class(struct MarioState *m);
 u32 mario_get_terrain_sound_addend(struct MarioState *m);
 struct Surface *resolve_and_return_wall_collisions(Vec3f pos, f32 offset, f32 radius);
+int resolve_and_return_multiple_wall_collisions(struct WallCollisionData *collisionData, Vec3f pos, f32 offset, f32 radius);
 f32 vec3f_find_ceil(Vec3f pos, f32 height, struct Surface **ceil);
 s32 mario_facing_downhill(struct MarioState *m, s32 turnYaw);
 u32 mario_floor_is_slippery(struct MarioState *m);

--- a/src/decomp/include/external_types.h
+++ b/src/decomp/include/external_types.h
@@ -24,6 +24,8 @@ struct SM64Surface
     int16_t force;
     uint16_t terrain;
     int32_t vertices[3][3];
+    int roomId;
+    int faceId;
 };
 
 struct SM64ObjectTransform

--- a/src/decomp/include/types.h
+++ b/src/decomp/include/types.h
@@ -263,6 +263,8 @@ struct Surface
     struct SurfaceObjectTransform *transform; // libsm64: added field
     u16 terrain; // libsm64: added field
     enum SM64ExternalSurfaceTypes eSurfaceType; //added external room type
+    int externalRoom;
+    int externalFace;
 };
 
 struct MarioBodyState

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -786,3 +786,15 @@ void sm64_level_set_active_mario(int marioId)
 {
 	level_set_active_mario(marioId);
 }
+
+float* sm64_get_mario_position(int marioId)
+{
+	if( marioId >= s_mario_instance_pool.size || s_mario_instance_pool.objects[marioId] == NULL )
+    {
+        return NULL;
+    }
+	
+	set_global_mario_state(marioId);
+	
+	return gMarioState->pos;
+}

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -157,4 +157,6 @@ extern SM64_LIB_FN void sm64_level_update_player_loaded_Rooms_with_clippers(int 
 extern SM64_LIB_FN void sm64_level_rooms_switch(int switchedRooms[][2], int switchedRoomsCount);
 extern SM64_LIB_FN void level_set_active_mario(int marioId);
 
+extern SM64_LIB_FN float* sm64_get_mario_position(int marioId);
+
 #endif//LIB_SM64_H

--- a/src/load_surfaces.c
+++ b/src/load_surfaces.c
@@ -214,6 +214,8 @@ static void engine_surface_from_lib_surface( struct Surface *surface, const stru
 
     surface->isValid = 1;
     surface->eSurfaceType = externalType;
+    surface->externalRoom = libSurf->roomId;
+    surface->externalFace = libSurf->faceId;
 }
 
 #pragma endregion


### PR DESCRIPTION
https://imgur.com/dfwyIJJ

By default it is at Mario's feet when in ground and when in water it is bellow him and he rotates around it (you can see at the beginning when he is not submerged how he pivots around the surface of a sphere).

Moved both the camera and Mario's geometry to the center of the sphere. This allows to avoid clipping issues because the collision radius was based on the sphere and not Mario geometry. Since I need to reduce re radius to allow Mario in tight spots he needs to actually be at the sphere.

Collision checks were also redone.
It gets all the walls he collides and not only the last one the algorithm finds (default behavior in sm64).
If that wall is not horizontal, is not the ceiling and not the floor then It ignores it. 
If It doesn't ignore the wall It will clip the movement of Mario in the direction of the normal of said wall so he doesn't move more in that direction but still allows movement in the other directions. This avoids him getting easily stuck when he barely touches a wall.
Then after this It does the ceiling and floor checks to avoid him getting too close to them and ending up clipping geometry.

the swimming just got 1000% better overall.

you could argue this is not pure SM64 gameplay but unfortunately the swimming mechanics where not meant for levels like these