### PR TITLE
Mario no longer teleports to water surface.

### DIFF
--- a/src/decomp/game/mario.c
+++ b/src/decomp/game/mario.c
@@ -1203,7 +1203,10 @@ s32 set_water_plunge_action(struct MarioState *m) {
     m->forwardVel = m->forwardVel / 4.0f;
     m->vel[1] = m->vel[1] / 2.0f;
 
-    m->pos[1] = m->waterLevel - 100;
+    if(abs(m->pos[1]-m->waterLevel) < 100)
+    {
+        m->pos[1] = m->waterLevel - 100;
+    }
 
     m->faceAngle[2] = 0;
 


### PR DESCRIPTION
He only tries to get 100 units bellow the water level if he is 100units near the water level. This fixes dozy mode enable behavior, load/save mario position when inside water and other weird behaviors that could place Mario out of bounds.