### PR TITLE
Tweaked the ledge grab eval algorithm.

### DIFF
--- a/src/decomp/game/mario_step.c
+++ b/src/decomp/game/mario_step.c
@@ -371,7 +371,10 @@ u32 check_ledge_grab(struct MarioState *m, struct Surface *wall, Vec3f intendedP
     ledgePos[2] = nextPos[2] - wall->normal.z * 60.0f;
     ledgePos[1] = find_floor(ledgePos[0], nextPos[1] + 160.0f, ledgePos[2], &ledgeFloor);
 
-    if (ledgePos[1] - nextPos[1] <= 100.0f) {
+    // Originally this was 100.0f but that would make it difficult to grab regular
+    // Tomb Raider platforms that were 1 cell away and around 1 cell height.
+    // This in Tomb Raider is called standing jump grab.
+    if (ledgePos[1] - nextPos[1] <= 80.0f) {
         return FALSE;
     }
 


### PR DESCRIPTION
It didn't allow to grab a typical standing jump grab scenario since Mario would reach the necessary height as Lara would.

This is the typical scenario with a 1cell gap and 1 cell height platform. Although pro Mario players could manage another mechanic to get over the platform there are many situations where it is too frustrating for regular people (specially when it has a low ceiling that blocks some of the possible moves).

Example: https://streamable.com/eebpt2