### PR TITLE
Fix climbing ledges with a small height.

### DIFF
--- a/src/decomp/game/mario_actions_automatic.c
+++ b/src/decomp/game/mario_actions_automatic.c
@@ -560,9 +560,18 @@ s32 act_ledge_grab(struct MarioState *m) {
         m->actionTimer++;
     }
 
+    s32 hasSpaceForMario;
     // We need to recheck the ceiling in case it was not updated correctly
-    float ceilHeight = find_ceil(m->pos[0], m->pos[1], m->pos[2], &(m->ceil));
-    s32 hasSpaceForMario = (ceilHeight - m->floorHeight >= 160.0f);
+    if(m->ceilHeight==100000)
+    {
+        struct Surface *ceil;
+        float ceilHeight = find_ceil(m->pos[0], m->pos[1]+10, m->pos[2], &ceil);
+        hasSpaceForMario = (ceilHeight - m->floorHeight >= 160.0f);
+    }
+    else
+    {
+        hasSpaceForMario = (m->ceilHeight - m->floorHeight >= 160.0f);
+    }
 
     // Originally this was 0.9063078f but in tomb raider's maps it needs
     // to grab more slanted ledges

--- a/src/decomp/game/mario_actions_automatic.c
+++ b/src/decomp/game/mario_actions_automatic.c
@@ -562,7 +562,7 @@ s32 act_ledge_grab(struct MarioState *m) {
 
     s32 hasSpaceForMario;
     // We need to recheck the ceiling in case it was not updated correctly
-    if(m->ceilHeight==100000)
+    if(m->ceilHeight==100000 && m->ceil==NULL)
     {
         struct Surface *ceil;
         float ceilHeight = find_ceil(m->pos[0], m->pos[1]+10, m->pos[2], &ceil);


### PR DESCRIPTION
Find_ceil would get the ceiling below instead of the ceiling above. Now it only tries to find the ceiling if it's strictly necessary (if it has the default max value of 100000 and m->ceil is null (It means it couldn't find one since the room above is not loaded).