### PR TITLE
Fixed edge grab climbing in certain scenarios.

### DIFF
--- a/src/decomp/game/mario_actions_automatic.c
+++ b/src/decomp/game/mario_actions_automatic.c
@@ -566,7 +566,7 @@ s32 act_ledge_grab(struct MarioState *m) {
     {
         struct Surface *ceil;
         float ceilHeight = find_ceil(m->pos[0], m->pos[1]+10, m->pos[2], &ceil);
-        hasSpaceForMario = (ceilHeight - m->floorHeight >= 160.0f);
+        hasSpaceForMario = (ceilHeight<m->floorHeight) || (ceilHeight - m->floorHeight >= 160.0f);
     }
     else
     {


### PR DESCRIPTION
In some scenarios it would consider a ceiling bellow the floor and assume there was no space for mario to climb up. Now it checks if the ceiling is bellow the floor.

It fixed the identified issues and several other levels were tested to verify if this new check could create issues and none were found.